### PR TITLE
Reword some messages in MainActivity.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ private void copyTextToClipboard(String text) {
         ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);  
         ClipData clip = ClipData.newPlainText("AI Chat Message", text);  
         clipboard.setPrimaryClip(clip);  
-        Toast.makeText(getContext(), "The text is copied.", Toast.LENGTH_SHORT).show();  
     }  
     // For Android API 8, 9, 10 (Froyo, Gingerbread ->)  
   else {  
@@ -286,8 +285,8 @@ private void copyTextToClipboard(String text) {
   android.text.ClipboardManager clipboard =  
                 (android.text.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);  
         clipboard.setText(text);  
-        Toast.makeText(getContext(), "The text is copied (old method).", Toast.LENGTH_SHORT).show();  
     }  
+    Toast.makeText(getContext(), "Copied text.", Toast.LENGTH_SHORT).show();  
 }
 ```
 **Also, I want to warn everyone that I am only 16 years old. I am not a professional programmer; I used neural networks for development, etc. Please don't judge too harshly - the project is in beta testing!**

--- a/app/src/main/java/com/ymp/reold/ai/MainActivity.java
+++ b/app/src/main/java/com/ymp/reold/ai/MainActivity.java
@@ -317,7 +317,6 @@ public class MainActivity extends AppCompatActivity {
                 ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
                 ClipData clip = ClipData.newPlainText("AI Chat Message", text);
                 clipboard.setPrimaryClip(clip);
-                Toast.makeText(getContext(), "The text is copied.", Toast.LENGTH_SHORT).show();
             }
             // Для Android API 8, 9, 10 (Froyo, Gingerbread ->)
             else {
@@ -325,8 +324,8 @@ public class MainActivity extends AppCompatActivity {
                 android.text.ClipboardManager clipboard =
                         (android.text.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
                 clipboard.setText(text);
-                Toast.makeText(getContext(), "The text is copied (old method).", Toast.LENGTH_SHORT).show();
             }
+			Toast.makeText(getContext(), "Copied text.", Toast.LENGTH_SHORT).show();
         }
 
         private void deleteMessage(int position) {

--- a/app/src/main/java/com/ymp/reold/ai/MainActivity.java
+++ b/app/src/main/java/com/ymp/reold/ai/MainActivity.java
@@ -160,7 +160,7 @@ public class MainActivity extends AppCompatActivity {
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
                     dialog.cancel();
-                    Toast.makeText(MainActivity.this, "Without the API key, the application will not be able to run.", Toast.LENGTH_LONG).show();
+                    Toast.makeText(MainActivity.this, "Without the API key, this application will not function properly.", Toast.LENGTH_LONG).show();
                 }
             });
         } else {
@@ -178,7 +178,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         if (TextUtils.isEmpty(aiApiKey)) {
-            Toast.makeText(this, "Please enter your AI API key in the settings.", Toast.LENGTH_LONG).show();
+            Toast.makeText(this, "Please enter your AI API key in settings.", Toast.LENGTH_LONG).show();
             showApiKeyDialog(false);
             return;
         }
@@ -325,7 +325,7 @@ public class MainActivity extends AppCompatActivity {
                         (android.text.ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
                 clipboard.setText(text);
             }
-			Toast.makeText(getContext(), "Copied text.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(getContext(), "Copied text.", Toast.LENGTH_SHORT).show();
         }
 
         private void deleteMessage(int position) {


### PR DESCRIPTION
This PR rewords some messages to sound better, and makes the modern and legacy messages of copying things to the clipboard the same. While there's not a problem with having separate messages, the user probably doesn't care how the text was copied. As long as it was copied, it's fine to them, so just use the same message for both methods.

I would also like to state two things
* For one, I'm glad you've taken the time to make apps like this. The Legacy Android scene doesn't get as much as the iOS scene does, so it's nice to see something come up.
* I've noticed your minSDK is set to 8, and I'm unable to build the app without bumping it to 9 (conscrypt's minimum). Was this a mistake?
